### PR TITLE
Add persistent authentication

### DIFF
--- a/lib/di/blocs.dart
+++ b/lib/di/blocs.dart
@@ -11,4 +11,9 @@ final List<BlocProvider> blocs = [
       authRepository: context.read<AuthRepository<UserModel>>(),
     ),
   ),
+  BlocProvider<AuthCubit>(
+    create: (context) => AuthCubit(
+      authRepository: context.read<AuthRepository<UserModel>>(),
+    )..checkAuthStatus(),
+  ),
 ];

--- a/lib/di/dependency_injector.dart
+++ b/lib/di/dependency_injector.dart
@@ -12,6 +12,7 @@ import 'package:track_that_flutter/repositories/authRepo.dart';
 import 'package:track_that_flutter/repositories/impl/authRepo_impl.dart';
 import 'package:track_that_flutter/state_management/cubits/first_cubit/register_cubit.dart';
 import 'package:track_that_flutter/state_management/cubits/first_cubit/login_cubit.dart';
+import 'package:track_that_flutter/state_management/cubits/auth/auth_cubit.dart';
 
 part 'blocs.dart';
 part 'mappers.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,30 +3,52 @@ import 'package:track_that_flutter/di/dependency_injector.dart';
 import 'package:track_that_flutter/network/firebase_config.dart';
 import 'package:track_that_flutter/routers/app_router.dart';
 import 'package:track_that_flutter/theme/AppTheme.dart';
+import 'package:track_that_flutter/state_management/cubits/auth/auth_cubit.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  
-  await FirebaseConfig.init();
 
+  await FirebaseConfig.init();
   runApp(const TrackThatFlutterApp());
 }
 
-class TrackThatFlutterApp extends StatelessWidget {
+class TrackThatFlutterApp extends StatefulWidget {
   const TrackThatFlutterApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
-  final appRouter = AppRouter();
+  State<TrackThatFlutterApp> createState() => _TrackThatFlutterAppState();
+}
 
+class _TrackThatFlutterAppState extends State<TrackThatFlutterApp> {
+  late final AppRouter _router;
+
+  @override
+  void initState() {
+    super.initState();
+    _router = AppRouter();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return DependencyInjector(
-           child: MaterialApp.router(
-      title: 'Track That Flutter',
-      theme: AppTheme.lightTheme,
-      darkTheme: AppTheme.darkTheme,
-      themeMode: ThemeMode.system,
-      routerConfig: appRouter.config(),
-    ));
+      child: BlocListener<AuthCubit, AuthState>(
+        listener: (context, state) {
+          if (state is AuthAuthenticated) {
+            _router.replaceAll([const WelcomeRoute()]);
+          } else if (state is AuthUnauthenticated) {
+            _router.replaceAll([const LoginRoute()]);
+          }
+        },
+        child: MaterialApp.router(
+          title: 'Track That Flutter',
+          theme: AppTheme.lightTheme,
+          darkTheme: AppTheme.darkTheme,
+          themeMode: ThemeMode.system,
+          routerConfig: _router.config(),
+        ),
+      ),
+    );
   }
 }
+
 

--- a/lib/network/firebase_service.dart
+++ b/lib/network/firebase_service.dart
@@ -81,4 +81,22 @@ class FirebaseService {
       return null;
     }
   }
+
+  Future<Map<String, dynamic>?> getCurrentUserData() async {
+    final user = _auth.currentUser;
+    if (user == null) return null;
+    try {
+      final doc = await _firestore.collection('utenti').doc(user.uid).get();
+      if (doc.exists) {
+        return doc.data() as Map<String, dynamic>;
+      }
+    } catch (e) {
+      debugPrint('Errore nel recupero dell\'utente corrente: $e');
+    }
+    return null;
+  }
+
+  Future<void> signOut() async {
+    await _auth.signOut();
+  }
 }

--- a/lib/network/service/impl/authService_impl.dart
+++ b/lib/network/service/impl/authService_impl.dart
@@ -26,9 +26,8 @@ class AuthserviceImpl implements Authservice {
   }
 
   @override
-  Future<void> logout() {
-    // Implement logout logic here
-    throw UnimplementedError();
+  Future<void> logout() async {
+    await _firebaseService.signOut();
   }
 
   @override
@@ -46,7 +45,6 @@ class AuthserviceImpl implements Authservice {
 
   @override
   Future<Map<String, dynamic>?> getCurrentUser() {
-    // Implement logic to get current user here
-    throw UnimplementedError();
+    return _firebaseService.getCurrentUserData();
   }
 }

--- a/lib/repositories/impl/authRepo_impl.dart
+++ b/lib/repositories/impl/authRepo_impl.dart
@@ -1,8 +1,10 @@
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:track_that_flutter/mappers/UserMapper.dart';
 import 'package:track_that_flutter/model/entities/user.dart';
 import 'package:track_that_flutter/network/dto/UserDto.dart';
 import 'package:track_that_flutter/network/service/authService.dart';
 import 'package:track_that_flutter/repositories/authRepo.dart';
+import 'package:track_that_flutter/other/contants/AppConstants.dart';
 
 class AuthRepositoryImpl implements AuthRepository<UserModel> {
   Authservice authService;
@@ -17,13 +19,16 @@ class AuthRepositoryImpl implements AuthRepository<UserModel> {
       throw Exception("Login failed");
     }
     UserModel userModel = userMapper.fromDTO(userDto);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(AppConstants.userIdKey, userModel.id);
     return userModel;
   }
 
   @override
-  Future<void> logout() {
-    // Implement logout logic here
-    throw UnimplementedError();
+  Future<void> logout() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(AppConstants.userIdKey);
+    await authService.logout();
   }
 
   @override
@@ -39,16 +44,27 @@ class AuthRepositoryImpl implements AuthRepository<UserModel> {
     }
     print("Dati ricevuti dalla register: $data");
 
+    final user = userMapper.fromDTO(UserDTO(
+      id: data['uid'],
+      name: data['name'],
+      email: data['email'],
+    ));
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(AppConstants.userIdKey, user.id);
+    return user;
+  }
+
+  @override
+  Future<UserModel?> getCurrentUser() async {
+    final prefs = await SharedPreferences.getInstance();
+    final savedId = prefs.getString(AppConstants.userIdKey);
+    if (savedId == null) return null;
+    final data = await authService.getCurrentUser();
+    if (data == null) return null;
     return userMapper.fromDTO(UserDTO(
       id: data['uid'],
       name: data['name'],
       email: data['email'],
     ));
-  }
-
-  @override
-  Future<UserModel?> getCurrentUser() {
-    // Implement logic to get current user here
-    throw UnimplementedError();
   }
 }

--- a/lib/state_management/cubits/auth/auth_cubit.dart
+++ b/lib/state_management/cubits/auth/auth_cubit.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:track_that_flutter/model/entities/user.dart';
+import 'package:track_that_flutter/repositories/authRepo.dart';
+
+part 'auth_state.dart';
+
+class AuthCubit extends Cubit<AuthState> {
+  final AuthRepository<UserModel> authRepository;
+  AuthCubit({required this.authRepository}) : super(AuthInitial());
+
+  Future<void> checkAuthStatus() async {
+    emit(AuthLoading());
+    try {
+      final user = await authRepository.getCurrentUser();
+      if (user != null) {
+        emit(AuthAuthenticated(user));
+      } else {
+        emit(AuthUnauthenticated());
+      }
+    } catch (_) {
+      emit(AuthUnauthenticated());
+    }
+  }
+
+  Future<void> logout() async {
+    await authRepository.logout();
+    emit(AuthUnauthenticated());
+  }
+}

--- a/lib/state_management/cubits/auth/auth_state.dart
+++ b/lib/state_management/cubits/auth/auth_state.dart
@@ -1,0 +1,14 @@
+part of 'auth_cubit.dart';
+
+abstract class AuthState {}
+
+class AuthInitial extends AuthState {}
+
+class AuthLoading extends AuthState {}
+
+class AuthAuthenticated extends AuthState {
+  final UserModel user;
+  AuthAuthenticated(this.user);
+}
+
+class AuthUnauthenticated extends AuthState {}

--- a/lib/ui/pages/login_page.dart
+++ b/lib/ui/pages/login_page.dart
@@ -5,6 +5,7 @@ import 'package:track_that_flutter/model/entities/user.dart';
 import 'package:track_that_flutter/routers/app_router.dart';
 import 'package:track_that_flutter/state_management/cubits/first_cubit/login_cubit.dart';
 import 'package:track_that_flutter/state_management/cubits/first_cubit/login_cubit_state.dart';
+import 'package:track_that_flutter/state_management/cubits/auth/auth_cubit.dart';
 import 'package:track_that_flutter/theme/ColorPalette.dart';
 import 'package:track_that_flutter/theme/Dimensions.dart';
 
@@ -47,6 +48,7 @@ class _LoginPageState extends State<LoginPage> {
         child: BlocConsumer<LoginCubit, LoginCubitState>(
           listener: (context, state) {
             if (state is LoginSuccessState) {
+              context.read<AuthCubit>().checkAuthStatus();
               context.router.push(const WelcomeRoute());
             } else if (state is LoginErrorState) {
               // Show an error message if login fails

--- a/lib/ui/pages/register_page.dart
+++ b/lib/ui/pages/register_page.dart
@@ -5,6 +5,7 @@ import 'package:track_that_flutter/model/entities/user.dart';
 import 'package:track_that_flutter/routers/app_router.dart';
 import 'package:track_that_flutter/state_management/cubits/first_cubit/register_cubit.dart';
 import 'package:track_that_flutter/state_management/cubits/first_cubit/register_cubit_state.dart';
+import 'package:track_that_flutter/state_management/cubits/auth/auth_cubit.dart';
 import 'package:track_that_flutter/theme/ColorPalette.dart';
 import 'package:track_that_flutter/theme/Dimensions.dart';
 
@@ -51,6 +52,7 @@ class _RegisterPageState extends State<RegisterPage> {
           listener: (context, state) {
             if (state is RegisterSuccessState) {
               // Dopo la registrazione navighiamo alla pagina di benvenuto
+              context.read<AuthCubit>().checkAuthStatus();
               context.router.replace(const WelcomeRoute());
             } else if (state is RegisterErrorState) {
               ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/ui/pages/welcome_page.dart
+++ b/lib/ui/pages/welcome_page.dart
@@ -1,8 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:track_that_flutter/state_management/cubits/first_cubit/login_cubit.dart';
-import 'package:track_that_flutter/state_management/cubits/first_cubit/login_cubit_state.dart';
+import 'package:track_that_flutter/state_management/cubits/auth/auth_cubit.dart';
 
 @RoutePage()
 class WelcomePage extends StatelessWidget {
@@ -10,30 +9,32 @@ class WelcomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<LoginCubit, LoginCubitState>(
-      builder: (BuildContext context, state) {
-        if (state is LoginSuccessState) {
-          final userName = state.user.name;
-
+    return BlocBuilder<AuthCubit, AuthState>(
+      builder: (context, state) {
+        if (state is AuthLoading || state is AuthInitial) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        } else if (state is AuthAuthenticated) {
+          final user = state.user;
           return Scaffold(
             appBar: AppBar(
-              title: Text(userName),
+              title: Text(user.name),
             ),
             body: Center(
               child: Text(
-                'Ciao, $userName!',
+                'Ciao, ${user.name}!',
                 style: Theme.of(context).textTheme.headlineMedium,
               ),
             ),
           );
+        } else {
+          return const Scaffold(
+            body: Center(
+              child: Text('Utente non autenticato'),
+            ),
+          );
         }
-
-        // Stato di fallback
-        return const Scaffold(
-          body: Center(
-            child: Text('Utente non autenticato'),
-          ),
-        );
       },
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   firebase_core: ^3.15.2
   firebase_auth: ^5.7.0
   cloud_firestore: ^5.6.12
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- create `AuthCubit` with states to manage authentication
- provide `AuthCubit` via dependency injector
- update `main.dart` to navigate based on AuthCubit state
- refactor login, register, and welcome pages to use the new cubit

## Testing
- `flutter pub get` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688095aa84f083299501885997602d3f